### PR TITLE
Fix bug with queries by changing the archetype backend

### DIFF
--- a/src/Detail/ArchetypeManager.cpp
+++ b/src/Detail/ArchetypeManager.cpp
@@ -6,32 +6,36 @@ namespace etcs {
 
 namespace detail {
 
-std::size_t Archetype::superHash(const Archetype& archetype, lsd::type_id typeId) {
-	auto hash = archetype.m_components.size() + 1;
+std::size_t Archetype::superHash(lsd::type_id typeId) {
+	auto hash = m_components.size() + 1;
 
 	auto inserted = false;
 
-	for (const auto& component : archetype.m_components) {
-		if (component.first > typeId) {
+	for (const auto& [id, _] : m_components) {
+		if (id > typeId) {
 			inserted = true;
 			hash ^= reinterpret_cast<std::uintptr_t>(typeId) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 		}
 
-		hash ^= reinterpret_cast<std::uintptr_t>(component.first) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+		hash ^= reinterpret_cast<std::uintptr_t>(id) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 	}
 	if (!inserted) hash ^= reinterpret_cast<std::uintptr_t>(typeId) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 
 	return hash;
 }
 
-std::size_t Archetype::subHash(const Archetype& archetype, lsd::type_id typeId) {
-	auto hash = archetype.m_components.size() - 1;
+std::size_t Archetype::subHash(lsd::type_id typeId) {
+	auto hash = m_components.size() - 1;
 
-	for (const auto& component : archetype.m_components)
-		if (component.first != typeId)
-			hash ^= reinterpret_cast<std::uintptr_t>(component.first) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	for (const auto& [id, _] : m_components)
+		if (id != typeId)
+			hash ^= reinterpret_cast<std::uintptr_t>(id) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 
 	return hash;
+}
+
+void Archetype::insertEntity(object_id entityId) {
+	m_entities.emplace(entityId);
 }
 
 void Archetype::eraseEntity(object_id entityId) {
@@ -42,15 +46,51 @@ void Archetype::eraseEntity(object_id entityId) {
 		m_entities.erase(it);
 
 		for (auto& component : m_components) component.second.eraseComponent(index);
-	} else throw std::out_of_range("etcs::EnitityComponentSystem::Archetype::eraseEntity(): Tried to erase entity with nonexistant ID!");
+	} else throw std::out_of_range("etscs::EnitityComponentSystem::Archetype::eraseEntity(): Tried to erase entity with nonexistant ID!");
 }
 
+vector_t<lsd::type_id> Archetype::typeIds() const {
+	vector_t<lsd::type_id> res { };
+	res.reserve(m_components.size());
 
-[[nodiscard]] Archetype* ArchetypeManager::archetype(std::size_t hash) {
-	auto archetype = m_archetypes.find(hash);
+	for (const auto& [id, _] : m_components) res.push_back(id);
 
-	if (archetype != m_archetypes.end()) return archetype->get();
-	else return nullptr;
+	return res;
+}
+
+void ArchetypeManager::querySupersets(vector_t<Archetype*>& archetypes, vector_t<lsd::type_id> types) {
+	auto baseArchetypeArray = m_archetypeLookup.find(types.front());
+	if (baseArchetypeArray == m_archetypeLookup.end()) return;	
+
+	vector_t<lsd::UnorderedSparseSet<Archetype*>> archetypeLookup;
+	archetypeLookup.reserve(types.size() - 1);
+
+	for (auto typeIt = ++types.begin(); typeIt != types.end(); typeIt++) {
+		auto archetypeArray = m_archetypeLookup.find(*typeIt);
+
+		if (archetypeArray == m_archetypeLookup.end()) return;
+		
+		if (archetypeArray->second.size() < baseArchetypeArray->second.size()) {
+			archetypeLookup.emplace_back(baseArchetypeArray->second.begin(), baseArchetypeArray->second.end());
+
+			baseArchetypeArray = archetypeArray;
+		} else archetypeLookup.emplace_back(archetypeArray->second.begin(), archetypeArray->second.end());
+	}
+
+	archetypes.reserve(baseArchetypeArray->second.size());
+
+	for (auto archetype : baseArchetypeArray->second) {
+		bool found = true;
+
+		for (const auto& lookup : archetypeLookup) {
+			if (!lookup.contains(archetype)) {
+				found = false;
+				break;
+			}
+		}
+
+		if (found) archetypes.push_back(archetype);
+	}
 }
 
 } // namespace detail

--- a/src/Detail/EntityManager.cpp
+++ b/src/Detail/EntityManager.cpp
@@ -21,20 +21,21 @@ object_id EntityManager::uniqueId() {
 }
 
 Entity EntityManager::insert(string_view_t name) {
-	auto archetype = m_world->m_archetypes.defaultArchetype();
+	auto archetype = m_world->m_archetypes.baseArchetype();
 
 	auto res = m_lookup.emplace(EntityData(uniqueId(), name), archetype).first;
-	archetype->m_entities.emplace(res->first.m_id);
+	archetype->insertEntity(res->first.m_id);
 
 	return Entity(res->first.m_id, res - m_lookup.begin(), m_world);
 }
+
 Entity EntityManager::insert(string_view_t name, object_id parentId) {
 	if (auto parent = m_lookup.find(parentId); parent != m_lookup.end()) {
 		if (auto it = parent->first.m_children.find(name); it == parent->first.m_children.end()) {
-			auto archetype = m_world->m_archetypes.defaultArchetype();
+			auto archetype = m_world->m_archetypes.baseArchetype();
 
 			auto eIt = m_lookup.emplace(EntityData(uniqueId(), name, &parent->first), archetype).first;
-			archetype->m_entities.emplace(eIt->first.m_id);
+			archetype->insertEntity(eIt->first.m_id);
 
 			m_lookup.find(parentId)->first.m_children.emplace(EntityView { eIt->first.m_id, eIt->first.m_name }); // find parent again because of memory invalidation
 
@@ -61,7 +62,7 @@ void EntityManager::erase(object_id id) {
 void EntityManager::clear(object_id id) {
 	auto& archetype = m_lookup.at(id);
 	archetype->eraseEntity(id);
-	archetype = m_world->m_archetypes.defaultArchetype();
+	archetype = m_world->m_archetypes.baseArchetype();
 }
 
 detail::EntityData& EntityManager::data(object_id id, std::size_t& index) {

--- a/src/EntityQuery.cpp
+++ b/src/EntityQuery.cpp
@@ -28,31 +28,25 @@ BasicQueryIterator& BasicQueryIterator::operator++() {
 }
 
 void BasicQueryIterator::incrementIterator() {
-	if (m_iterator != m_end && ++m_entityIterator == (*m_iterator)->m_entities.end() && ++m_iterator != m_end)
+	if (m_iterator != m_end && ++m_entityIterator >= (*m_iterator)->m_entities.end() && ++m_iterator != m_end)
 		m_entityIterator = (*m_iterator)->m_entities.begin();
 }
 
 void BasicQueryIterator::skipInvalid() {
 	while (
 		m_iterator != m_end && // if the archetype iterator is at the end, don't increment
-		(!(*m_iterator)->m_entities.empty() || // if the archetype is empty, don't increment
-		!m_query->world()->m_entities.data((*m_entityIterator), m_entityIndex).m_active) // check if the entity is active
+		(
+			(*m_iterator)->m_entities.empty() || // if the archetype is empty, don't increment
+			!m_query->world()->m_entities.data((*m_entityIterator), m_entityIndex).m_active // check if the entity is active
+		)
 	) incrementIterator();
 }
 
 
 // BasicEntityQuery
 
-BasicEntityQuery::BasicEntityQuery(WorldData* world, std::size_t typeHash) : m_world(world) {
-	loopAndAddArchetype(world->m_archetypes.archetype(typeHash));
-}
-
-void BasicEntityQuery::loopAndAddArchetype(Archetype* archetype) {
-	if (archetype) {
-		m_archetypes.push_back(archetype);
-
-		for (const auto& edge : archetype->m_edges) loopAndAddArchetype(edge.second.superset);
-	}
+BasicEntityQuery::BasicEntityQuery(WorldData* world, const vector_t<lsd::type_id>& typeIds) : m_world(world) {
+	world->m_archetypes.querySupersets(m_archetypes, typeIds);
 }
 
 BasicQueryIterator BasicEntityQuery::begin() {


### PR DESCRIPTION
Originally, the archetypes were linked together in a tree as super- and subsets, but that didn't really work, and it was very inefficient, so I just opted to find the intersection of the archetypes. It works very nicely.